### PR TITLE
[Bug] Client Disconnect시 에러 해결

### DIFF
--- a/Assets/DefaultNetworkPrefabs.asset
+++ b/Assets/DefaultNetworkPrefabs.asset
@@ -131,7 +131,61 @@ MonoBehaviour:
     SourceHashToOverride: 0
     OverridingTargetPrefab: {fileID: 0}
   - Override: 0
-    Prefab: {fileID: 4658183709684643492, guid: 98ac3559ab9171247bda0f4f8b0ec60e,
+    Prefab: {fileID: 4749613076485015473, guid: 7223ae27945944f4b94a0231faa71b19,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 2887910004441748301, guid: 3a517a380c9b42e47ae97404ae19d999,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: 9456291201cd6f2488ab5b64492260ea,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: aa3d106956c0fc34bb8bee434c038ea8,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: b94499d34e9dd434d9a2dbe5c5315aee,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: 2d922738b518e8149923ccb2a935cd7d,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: 83e754eb118c3724699ddab648d6acc8,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: 8424de64719a6074f8490fb3e0579c71,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: 737cb325f53f66c4986937595a92a2f4,
+      type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4760297340198228138, guid: 6569f7091e5f6c946a0c2bfb2611c38b,
       type: 3}
     SourcePrefabToOverride: {fileID: 0}
     SourceHashToOverride: 0

--- a/Assets/Resources/Prefabs/Lobby/Map.prefab
+++ b/Assets/Resources/Prefabs/Lobby/Map.prefab
@@ -1303,7 +1303,7 @@ GameObject:
   - component: {fileID: 1740340731632160865}
   m_Layer: 0
   m_Name: 'Red Spawn Point '
-  m_TagString: Untagged
+  m_TagString: Red Spawn Point
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3343,6 +3343,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6488995887151591084, guid: 3b69376290d1f3e43a31a95a4c5dda68,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3889473959
+      objectReference: {fileID: 0}
     - target: {fileID: 6773205007094766562, guid: 3b69376290d1f3e43a31a95a4c5dda68,
         type: 3}
       propertyPath: m_Type
@@ -3798,6 +3803,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6488995887151591084, guid: 3b69376290d1f3e43a31a95a4c5dda68,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3889473959
       objectReference: {fileID: 0}
     - target: {fileID: 6773205007094766562, guid: 3b69376290d1f3e43a31a95a4c5dda68,
         type: 3}
@@ -4803,6 +4813,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6488995887151591084, guid: 3b69376290d1f3e43a31a95a4c5dda68,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3889473959
       objectReference: {fileID: 0}
     - target: {fileID: 6773205007094766562, guid: 3b69376290d1f3e43a31a95a4c5dda68,
         type: 3}
@@ -6347,6 +6362,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6488995887151591084, guid: 3b69376290d1f3e43a31a95a4c5dda68,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3889473959
+      objectReference: {fileID: 0}
     - target: {fileID: 6773205007094766562, guid: 3b69376290d1f3e43a31a95a4c5dda68,
         type: 3}
       propertyPath: m_Type
@@ -6906,6 +6926,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6488995887151591084, guid: 3b69376290d1f3e43a31a95a4c5dda68,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3889473959
       objectReference: {fileID: 0}
     - target: {fileID: 6773205007094766562, guid: 3b69376290d1f3e43a31a95a4c5dda68,
         type: 3}
@@ -7933,6 +7958,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6488995887151591084, guid: 3b69376290d1f3e43a31a95a4c5dda68,
+        type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3889473959
       objectReference: {fileID: 0}
     - target: {fileID: 6773205007094766562, guid: 3b69376290d1f3e43a31a95a4c5dda68,
         type: 3}

--- a/Assets/Scripts/Connection/ConnectionState/HostingState.cs
+++ b/Assets/Scripts/Connection/ConnectionState/HostingState.cs
@@ -21,7 +21,7 @@ namespace RaB.Connection
             // 현재 Scene이 InGame일 때는 Lobby Scene으로 이동해야 한다.
             if (SceneManager.GetActiveScene().name == SceneType.InGame.ToString())
             {
-                SceneLoadManager.Instance.LoadScene(SceneType.Lobby.ToString(), useNetworkSceneManager: true);
+                InGameManager.Instance.EndGameServerRpc();
             }
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#45 [Bug] Client Disconnect 에러

## 📝작업 내용

1. Ingame Scene에서 Client Disconnect 이벤트 발생 시 Lobby Scene으로 돌아가는 로직을 변경하여 플레이어 오브젝트가 모두 파괴 될 수 있게 변경하였습니다.
2. Lobby Map에서 Red Spawn Point Tag가 누락되어 Client에서 커서 락이 되지 않는 현상을 수정하였습니다.
3. Basic ping을 DefaultNetworkPrefabs에서 제거하였습니다.